### PR TITLE
Update webhook to 1.19

### DIFF
--- a/webhook/go.mod
+++ b/webhook/go.mod
@@ -1,14 +1,19 @@
 module github.com/reload/reviewbot/webhook
 
-go 1.16
+go 1.19
 
 require (
 	github.com/containrrr/shoutrrr v0.6.1
+	github.com/rickar/cal/v2 v2.1.5
+	gopkg.in/go-playground/webhooks.v5 v5.17.0
+)
+
+require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
-	github.com/rickar/cal/v2 v2.1.5
+	github.com/stretchr/testify v1.5.1 // indirect
 	golang.org/x/sys v0.0.0-20220803195053-6e608f9ce704 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
-	gopkg.in/go-playground/webhooks.v5 v5.17.0
 )


### PR DESCRIPTION
`go119` is available as a preview on Google Cloud Funtions.
